### PR TITLE
Fix node6 native

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,7 +121,7 @@ function generateRequireInfo (moduleId) {
     moduleId: moduleId,
     callingFile: callingFile,
     native: native,
-    extname: path.extname(absPath),
+    extname: absPath? path.extname(absPath): '',
     thirdParty: thirdParty,
     absPath: absPath,
     absPathResolvedCorrectly: absPathResolvedCorrectly,

--- a/test/test.js
+++ b/test/test.js
@@ -88,6 +88,14 @@ describe("intercept-require", function () {
       restore();
     });
 
+    it("should not throw on native modules", function () {
+      const restore = intercept(() => {});
+      expect(function() {
+        require('fs');
+      }).toNotThrow();
+      restore();
+    });
+
     it("passes the result and some info to the listener", function () {
       let calc, result, info;
       function listener (r, i) {


### PR DESCRIPTION
The intercept fails for native modules in node6. In that case. absPath remains undefined, which causes path.extname to fail in node 6, as it no longer accepts undefined.

The behavior of path.extname in node 4 when undefined is passed in is to return an empty string, so the fix is to check for undefined and return an empty string directly if it is.

These are the relevant lines: https://github.com/nickb1080/intercept-require/blob/master/lib/index.js#L108-L130

The error is easy to reproduce, use [n](https://github.com/tj/n) to easily switch between node versions. I added a test as well. To reproduce, first merge my first commit, run the test under node 6 and see it fail. Then merge the second commit and see it pass.